### PR TITLE
Update requirements

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,8 @@ For instructions on how to use this and the access control features to use it fo
 ## Dependencies
 
 - Microsoft .NET Core 3.1
+- Microsoft Windows
+- Microsoft Visual Studio
 - [.NET FHIR API](https://github.com/FirelyTeam/firely-net-sdk)
 
 The Identity Provider runs with preconfigured values in memory, so it has no database dependencies.

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ For instructions on how to use this and the access control features to use it fo
 ## Dependencies
 
 - Microsoft .NET Core 3.1
-- Microsoft Windows
+- Microsoft Windows (to run Powershell script to generate SSL certs)
 - Microsoft Visual Studio
 - [.NET FHIR API](https://github.com/FirelyTeam/firely-net-sdk)
 


### PR DESCRIPTION
The certificate generation script is unfortunately limited to just Windows at the moment:

```
scripts> ./GenerateSSLCertificate.ps1
New-SelfSignedCertificate: /home/vadi/Programs/Vonk.IdentityServer.Test/scripts/GenerateSSLCertificate.ps1:7
Line |
   7 |  $certificate = New-SelfSignedCertificate `
     |                 ~~~~~~~~~~~~~~~~~~~~~~~~~
     | The term 'New-SelfSignedCertificate' is not recognized as a name of a cmdlet, function, script file, or executable program. Check
     | the spelling of the name, or if a path was included, verify that the path is correct and try again.

cerFilePath = /home/vadi/Programs/Vonk.IdentityServer.Test/scripts\..\Vonk.IdentityServer.Test\ssl_cert.cer
```

And without the certificate, the server does not launch:

```
 dotnet run
Unhandled exception. Interop+Crypto+OpenSslCryptographicException: error:2006D080:BIO routines:BIO_new_file:no such file
   at Interop.Crypto.CheckValidOpenSslHandle(SafeHandle handle)
   at Internal.Cryptography.Pal.OpenSslX509CertificateReader.FromFile(String fileName, SafePasswordHandle password, X509KeyStorageFlags keyStorageFlags)
```